### PR TITLE
Fix minor but noticeable errors with v5 update

### DIFF
--- a/src/components/features.js
+++ b/src/components/features.js
@@ -158,6 +158,8 @@ const Layout = ({ children }) => (
                   <a
                     style={{ textDecoration: 'none', color: '#99A93A' }}
                     href="https://joshua0308.github.io/calculator/"
+                    target="_blank"
+                    rel="noopener noreferrer"
                   >
                     Calculator
                 </a>{' '}
@@ -165,6 +167,8 @@ const Layout = ({ children }) => (
                   <a
                     style={{ textDecoration: 'none', color: '#99A93A' }}
                     href="http://reactime-demo2.us-east-1.elasticbeanstalk.com/"
+                    target="_blank"
+                    rel="noopener noreferrer"
                   >
                     Bitcoin Price
                 </a>

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -38,13 +38,32 @@ const HeaderContainer = styled.header`
   height: 30px;
   padding: 50px;
   z-index: 2;
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
+  -ms-flex-pack: distribute;
   justify-content: space-around;
+
+  -webkit-box-align: center;
+  -ms-flex-align: center;
   align-items: center;
-  background: linear-gradient(#1c1d1f 75%, #FFFFFF00);
+
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(75%, rgb(28,29,31)), to(rgb(28,29,31, 0)));
+  background: -o-linear-gradient(rgb(28,29,31) 75%, rgb(28,29,31, 0));
+  background: linear-gradient(rgb(28,29,31) 75%, rgb(28,29,31, 0));
+
+  -webkit-transition: 0.2s;
+  -o-transition: 0.2s;
   transition: 0.2s;
+
   @media (max-width: 600px) {
+    -webkit-box-pack: center;
+    -ms-flex-pack: center;
     justify-content: center;
+
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+    -ms-flex-direction: column;
     flex-direction: column;
   }
 `
@@ -120,22 +139,20 @@ const Header = props => {
         <ul>
           <li style={{ marginBottom: `2px` }}>
             <a
-              href="https://www.npmjs.com/package/reactime"
-              title="ReacTime NPM Package"
-            >
-              npm
-            </a>
-          </li>
-          <li>
-            <a
               href="https://chrome.google.com/webstore/detail/reactime/cgibknllccemdnfhfpmjhffpjfeidjga?hl=en-US"
               title="ReacTime Chrome"
+              target="_blank"
+              rel="noopener noreferrer"
             >
               <FontAwesomeIcon icon={faChrome} />
             </a>
           </li>
           <li>
-            <a href="https://twitter.com/reactime" title="ReacTime Twitter">
+            <a href="https://twitter.com/reactime"
+              title="ReacTime Twitter"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               <FontAwesomeIcon icon={faTwitter} />
             </a>
           </li>
@@ -143,6 +160,8 @@ const Header = props => {
             <a
               href="https://linkedin.com/company/reactime"
               title="ReacTime LinkedIn"
+              target="_blank"
+              rel="noopener noreferrer"
             >
               <FontAwesomeIcon icon={faLinkedinIn} />
             </a>
@@ -154,6 +173,8 @@ const Header = props => {
               data-size="medium"
               data-show-count="true"
               aria-label="Star open-source-labs/reactime on GitHub"
+              target="_blank"
+              rel="noopener noreferrer"
             >
               Star
             </GitHubButton>

--- a/src/components/splash.js
+++ b/src/components/splash.js
@@ -24,6 +24,10 @@ const StyledDiv = styled.div`
   @media only screen and (max-width: 700px) {
     height: 90vh;
   }
+  /* IPAD PORTRAIT MODE */
+  @media only screen and (min-device-width : 768px) and (max-device-width : 1024px) and (orientation : portrait) { 
+    height: 70vh;
+  }
   display: flex;
   align-items: center;
   padding: 0px 1.0875rem 1.45rem;

--- a/src/components/team.js
+++ b/src/components/team.js
@@ -93,6 +93,7 @@ const StyledGridElement = styled.div`
   }
   a {
     text-decoration: none;
+    font-size: 0.8em;
   }
   /* h4:hover {
     cursor: pointer;
@@ -196,7 +197,7 @@ const Layout = ({ children }) => {
                     </p>
                   </div>
                 ) : null}
-                <a href="https://github.com/dubalol" title="Github">
+                <a href="https://github.com/dubalol" title="Github" target="_blank" rel="noopener noreferrer">
                   <FontAwesomeIcon icon={faGithub} />
                   {' '}
                   dubalol
@@ -221,7 +222,7 @@ const Layout = ({ children }) => {
                     </p>
                   </div>
                 ) : null}
-                <a href="https://github.com/andywongdev" title="Github">
+                <a href="https://github.com/andywongdev" title="Github" target="_blank" rel="noopener noreferrer">
                   <FontAwesomeIcon icon={faGithub} />
                   {' '}
                   andywongdev
@@ -246,7 +247,7 @@ const Layout = ({ children }) => {
                     </p>
                   </div>
                 ) : null}
-                <a href="https://github.com/mylee1995" title="Github">
+                <a href="https://github.com/mylee1995" title="Github" target="_blank" rel="noopener noreferrer">
                   <FontAwesomeIcon icon={faGithub} />
                   {' '}
                   mylee1995
@@ -265,7 +266,7 @@ const Layout = ({ children }) => {
                     </p>
                   </div>
                 ) : null}
-                <a href="https://github.com/crperezt" title="Github">
+                <a href="https://github.com/crperezt" title="Github" target="_blank" rel="noopener noreferrer">
                   <FontAwesomeIcon icon={faGithub} />
                   {' '}
                   crperezt
@@ -290,7 +291,7 @@ const Layout = ({ children }) => {
                     </p>
                   </div>
                 ) : null}
-                <a href="https://github.com/chriswillsflannery" title="Github">
+                <a href="https://github.com/chriswillsflannery" title="Github" target="_blank" rel="noopener noreferrer">
                   <FontAwesomeIcon icon={faGithub} />
                   {' '}
                   chriswillsflannery
@@ -315,7 +316,7 @@ const Layout = ({ children }) => {
                     </p>
                   </div>
                 ) : null}
-                <a href="https://github.com/davidchai717" title="Github">
+                <a href="https://github.com/davidchai717" title="Github" target="_blank" rel="noopener noreferrer">
                   <FontAwesomeIcon icon={faGithub} />
                   {' '}
                   davidchai717
@@ -334,7 +335,7 @@ const Layout = ({ children }) => {
                     </p>
                   </div>
                 ) : null}
-                <a href="https://github.com/edwinjmenendez" title="Github">
+                <a href="https://github.com/edwinjmenendez" title="Github" target="_blank" rel="noopener noreferrer">
                   <FontAwesomeIcon icon={faGithub} />
                   {' '}
                   edwinjmenendez
@@ -356,7 +357,7 @@ const Layout = ({ children }) => {
                     </p>
                   </div>
                 ) : null}
-                <a href="https://github.com/Ergi516" title="Github">
+                <a href="https://github.com/Ergi516" title="Github" target="_blank" rel="noopener noreferrer">
                   <FontAwesomeIcon icon={faGithub} />
                   {' '}
                   ergi516
@@ -375,7 +376,7 @@ const Layout = ({ children }) => {
                     </p>
                   </div>
                 ) : null}
-                <a href="https://github.com/aquinojardim" title="Github">
+                <a href="https://github.com/aquinojardim" title="Github" target="_blank" rel="noopener noreferrer">
                   <FontAwesomeIcon icon={faGithub} />
                   {' '}
                   {' '}
@@ -395,7 +396,7 @@ const Layout = ({ children }) => {
                     </p>
                   </div>
                 ) : null}
-                <a href="https://github.com/gpanciera" title="Github">
+                <a href="https://github.com/gpanciera" title="Github" target="_blank" rel="noopener noreferrer">
                   <FontAwesomeIcon icon={faGithub} />
                   {' '}
                   gpanciera
@@ -415,7 +416,7 @@ const Layout = ({ children }) => {
                     </p>
                   </div>
                 ) : null}
-                <a href="https://github.com/dubalol" title="Github">
+                <a href="https://github.com/dubalol" title="Github" target="_blank" rel="noopener noreferrer">
                   <FontAwesomeIcon icon={faGithub} />
                   {' '}
                   haejinjo
@@ -436,7 +437,7 @@ const Layout = ({ children }) => {
                     </p>
                   </div>
                 ) : null}
-                <a href="https://github.com/dubalol" title="Github">
+                <a href="https://github.com/dubalol" title="Github" target="_blank" rel="noopener noreferrer">
                   <FontAwesomeIcon icon={faGithub} />
                   {' '}
                   hienqn
@@ -456,7 +457,7 @@ const Layout = ({ children }) => {
                     </p>
                   </div>
                 ) : null}
-                <a href="https://github.com/dubalol" title="Github">
+                <a href="https://github.com/dubalol" title="Github" target="_blank" rel="noopener noreferrer">
                   <FontAwesomeIcon icon={faGithub} />
                   {' '}
                   jackc27
@@ -488,7 +489,7 @@ const Layout = ({ children }) => {
                     </p>
                   </div>
                 ) : null}
-                <a href="https://github.com/Joshua-Howard" title="Github">
+                <a href="https://github.com/Joshua-Howard" title="Github" target="_blank" rel="noopener noreferrer">
                   <FontAwesomeIcon icon={faGithub} />
                   {' '}
                   joshua-howard
@@ -513,7 +514,7 @@ const Layout = ({ children }) => {
                     </p>
                   </div>
                 ) : null}
-                <a href="https://github.com/joshua0308" title="Github">
+                <a href="https://github.com/joshua0308" title="Github" target="_blank" rel="noopener noreferrer">
                   <FontAwesomeIcon icon={faGithub} />
                   {' '}
                   joshua0308
@@ -533,7 +534,7 @@ const Layout = ({ children }) => {
                     </p>
                   </div>
                 ) : null}
-                <a href="https://github.com/dubalol" title="Github">
+                <a href="https://github.com/dubalol" title="Github" target="_blank" rel="noopener noreferrer">
                   <FontAwesomeIcon icon={faGithub} />
                   {' '}
                   kevinfey
@@ -554,7 +555,7 @@ const Layout = ({ children }) => {
                     </p>
                   </div>
                 ) : null}
-                <a href="https://github.com/nmwenz90" title="Github">
+                <a href="https://github.com/nmwenz90" title="Github" target="_blank" rel="noopener noreferrer">
                   <FontAwesomeIcon icon={faGithub} />
                   {' '}
                   nmwenz90
@@ -579,7 +580,7 @@ const Layout = ({ children }) => {
                     </p>
                   </div>
                 ) : null}
-                <a href="https://github.com/prasmalla" title="Github">
+                <a href="https://github.com/prasmalla" title="Github" target="_blank" rel="noopener noreferrer">
                   <FontAwesomeIcon icon={faGithub} />
                   {' '}
                   prasmalla
@@ -604,7 +605,7 @@ const Layout = ({ children }) => {
                     </p>
                   </div>
                 ) : null}
-                <a href="https://github.com/rajeebthegreat" title="Github">
+                <a href="https://github.com/rajeebthegreat" title="Github" target="_blank" rel="noopener noreferrer">
                   <FontAwesomeIcon icon={faGithub} />
                   {' '}
                   rajeebthegreat
@@ -627,7 +628,7 @@ const Layout = ({ children }) => {
                     </p>
                   </div>
                 ) : null}
-                <a href="https://github.com/rkwn" title="Github">
+                <a href="https://github.com/rkwn" title="Github" target="_blank" rel="noopener noreferrer">
                   <FontAwesomeIcon icon={faGithub} />
                   {' '}
                   rkwn
@@ -652,7 +653,7 @@ const Layout = ({ children }) => {
                     </p>
                   </div>
                 ) : null}
-                <a href="https://github.com/rocky9413" title="Github">
+                <a href="https://github.com/rocky9413" title="Github" target="_blank" rel="noopener noreferrer">
                   <FontAwesomeIcon icon={faGithub} />
                   {' '}
                   rocky9413
@@ -675,7 +676,7 @@ const Layout = ({ children }) => {
                     </p>
                   </div>
                 ) : null}
-                <a href="https://github.com/peachiecodes" title="Github">
+                <a href="https://github.com/peachiecodes" title="Github" target="_blank" rel="noopener noreferrer">
                   <FontAwesomeIcon icon={faGithub} />
                   {' '}
                   peachiecodes
@@ -700,7 +701,7 @@ const Layout = ({ children }) => {
                     </p>
                   </div>
                 ) : null}
-                <a href="https://github.com/rydang" title="Github">
+                <a href="https://github.com/rydang" title="Github" target="_blank" rel="noopener noreferrer">
                   <FontAwesomeIcon icon={faGithub} />
                   {' '}
                   rydang
@@ -725,7 +726,7 @@ const Layout = ({ children }) => {
                     </p>
                   </div>
                 ) : null}
-                <a href="https://github.com/starkspark" title="Github">
+                <a href="https://github.com/starkspark" title="Github" target="_blank" rel="noopener noreferrer">
                   <FontAwesomeIcon icon={faGithub} />
                   {' '}
                   starkspark
@@ -750,7 +751,7 @@ const Layout = ({ children }) => {
                     </p>
                   </div>
                 ) : null}
-                <a href="https://github.com/yujinkay" title="Github">
+                <a href="https://github.com/yujinkay" title="Github" target="_blank" rel="noopener noreferrer">
                   <FontAwesomeIcon icon={faGithub} />
                   {' '}
                   yujinkay

--- a/src/components/team.js
+++ b/src/components/team.js
@@ -416,7 +416,7 @@ const Layout = ({ children }) => {
                     </p>
                   </div>
                 ) : null}
-                <a href="https://github.com/dubalol" title="Github" target="_blank" rel="noopener noreferrer">
+                <a href="https://github.com/haejinjo" title="Github" target="_blank" rel="noopener noreferrer">
                   <FontAwesomeIcon icon={faGithub} />
                   {' '}
                   haejinjo
@@ -437,7 +437,7 @@ const Layout = ({ children }) => {
                     </p>
                   </div>
                 ) : null}
-                <a href="https://github.com/dubalol" title="Github" target="_blank" rel="noopener noreferrer">
+                <a href="https://github.com/hienqn" title="Github" target="_blank" rel="noopener noreferrer">
                   <FontAwesomeIcon icon={faGithub} />
                   {' '}
                   hienqn
@@ -457,7 +457,7 @@ const Layout = ({ children }) => {
                     </p>
                   </div>
                 ) : null}
-                <a href="https://github.com/dubalol" title="Github" target="_blank" rel="noopener noreferrer">
+                <a href="https://github.com/JackC27" title="Github" target="_blank" rel="noopener noreferrer">
                   <FontAwesomeIcon icon={faGithub} />
                   {' '}
                   jackc27
@@ -534,7 +534,7 @@ const Layout = ({ children }) => {
                     </p>
                   </div>
                 ) : null}
-                <a href="https://github.com/dubalol" title="Github" target="_blank" rel="noopener noreferrer">
+                <a href="https://github.com/kevinfey" title="Github" target="_blank" rel="noopener noreferrer">
                   <FontAwesomeIcon icon={faGithub} />
                   {' '}
                   kevinfey

--- a/src/components/visualState.js
+++ b/src/components/visualState.js
@@ -38,9 +38,8 @@ const Layout = ({ children }) => (
       <StyledDiv>
         <StyledMain
           data-sal="fade"
-          data-sal="slide-up"
           data-sal-delay="100"
-          data-sal-duration="600"
+          data-sal-duration="700"
           data-sal-easing="ease-out"
         >
           {children}

--- a/src/components/zoomInGridElement.js
+++ b/src/components/zoomInGridElement.js
@@ -3,14 +3,6 @@ import PropTypes from 'prop-types';
 // import { useStaticQuery, graphql } from "gatsby"
 import styled from 'styled-components';
 
-const styles = {
-  reactGreen: '#427aa1', // h4 font-color #072D2B
-  lightestGreen: '#BDD4DB',
-  gray: '#a3a3a3',
-
-  iconBColor: '#242529' // feature icon bg #E4C2B3
-};
-
 const StyledMain = styled.div`
 `;
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -47,35 +47,40 @@ const SplashDescription = styled.div`
   font-size: 1.5em;
 `;
 
+const DemoGifDescription = styled.h2`
+  text-align: center;
+  padding: 40px;
+
+  @media only screen and (max-width: 700px) {
+    padding: 0;
+  }
+`;
+
 const DemoGif = styled.img`
   @media only screen and (max-width: 700px) {
-    padding-left: 20px;
-    padding-right: 20px;
-    margin: 0px;
+    max-width: 90%;
   }
   @media only screen and (min-width: 700px) {
     minWidth: 40vw;
     maxWidth: 800px;
+    box-shadow: 5px 10px 15px black;
   }
-  box-shadow: 5px 10px 15px black;
-  margin: 30px;
+  margin: 30px 0px 30px 0px;
 `;
+
+const FeaturesTitle = styled.h2`
+  font-weight: 700;
+`
 
 const IndexPage = () => (
   <>
     <Splash>
       <SEO title="Home" />
-      <h1
+      <div
         style={{
-          fontFamily: 'Raleway',
-          fontSize: '1.5rem',
-          fontWeight: '500',
-          letterSpacing: '2px',
-          color: styles.reactGreen,
           margin: '80px 0 60px 0',
-          textAlign: 'center'
         }}
-      ></h1>
+      ></div>
       <SplashContainer>
         <Image />
         <SplashDescription>
@@ -106,6 +111,7 @@ const IndexPage = () => (
               }}
               href="https://osawards.com/react/"
               target="_blank"
+              rel="noopener noreferrer"
             >
               React Open Source Awards 2020
               </a>
@@ -129,6 +135,7 @@ const IndexPage = () => (
             }}
             href="https://chrome.google.com/webstore/detail/reactime/cgibknllccemdnfhfpmjhffpjfeidjga?hl=en-US"
             target="_blank"
+            rel="noopener noreferrer"
           >
             <strong>Download Now</strong>
           </a>
@@ -137,16 +144,16 @@ const IndexPage = () => (
     </Splash>
     <div id='demo'>
       <VisualState>
-        <h2 style={{ textAlign: 'center', padding: '40px' }}>
+        <DemoGifDescription>
           Track, Revert, <br />and Visualize your State
-      </h2>
-        <DemoGif src={demogif} alt="ReacTime Demo" />
+      </DemoGifDescription>
+        <DemoGif style={{ textAlign: 'center' }} src={demogif} alt="ReacTime Demo" />
       </VisualState>
     </div>
     <Features>
-      <h2>
-        <strong>Features</strong>
-      </h2>
+      <FeaturesTitle>
+        Features
+      </FeaturesTitle>
     </Features>
 
     <Team>
@@ -167,6 +174,7 @@ const IndexPage = () => (
             style={{ textDecoration: 'none', color: styles.redCode }}
             href="https://github.com/open-source-labs/reactime"
             target="_blank"
+            rel="noopener noreferrer"
           >
             contributing?
             </a>


### PR DESCRIPTION
**Main bugs fixed:**
- Github links for all v5 team contributors all linked to previous contributor, Abaas Khorrami's, github.
- Linear gradient mobile/tablet view should now display correctly without a ghostly white bar 
<img src ="https://user-images.githubusercontent.com/23015394/92569845-f53fa980-f235-11ea-9d56-7a96136a84d9.png" width="250" />


**Bugs found and fixed along the way:**
- NPM Package still linked on website. Has been removed (and currently is deprecated on the npm registry)
- Chris Flannery and Edwin Menendez's github handles were too large a font to fit on one line along with the FontAwesome Github Octocat icon => reduced font size for <a> tags in the team grid elements
- [Security vulnerability](https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/) with using target="_blank" as a quickfix solution for opening links in new tabs
- Demo gif slightly squeezed on single-column/responsive mobile view
- Slightly too large Splash component view height on iPads
- Lack of cross browser compatibility (see [CSS auto prefixer tool](https://autoprefixer.github.io/)!)
- Minor warnings about redundant JSX and unused variables, now cleaned up 